### PR TITLE
metadata.json: add GNOME 47 and 48 releases

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -4,7 +4,9 @@
   "name": "New Mail Indicator",
   "shell-version": [
     "45",
-    "46"
+    "46",
+    "47",
+    "48"
   ],
   "url": "https://github.com/fthx/new-mail-indicator",
   "uuid": "new-mail-indicator@fthx",


### PR DESCRIPTION
Fixes #19 